### PR TITLE
Begin transition from distutils to setuptools

### DIFF
--- a/src/python-apt-venv/setup.py
+++ b/src/python-apt-venv/setup.py
@@ -1,9 +1,10 @@
 #! /usr/bin/env python
 # $Id: setup.py,v 1.2 2002/01/08 07:13:21 jgg Exp $
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from distutils.sysconfig import parse_makefile
-from DistUtilsExtra.command import *
+from distutils.sysconfig import parse_makefile
+#from DistUtilsExtra.command import *
 import glob, os, string
 
 # The apt_pkg module


### PR DESCRIPTION
In smallest transition from distutils to setuptools, it becomes more obvious
that there are references to files not included in the Python package:

    IOError: [Errno 2] No such file or directory: 'python/makefile'

This matches the system-level coupling that was experienced earlier.